### PR TITLE
Downgraded Moq to the last version that embeds Castle.Core

### DIFF
--- a/src/Tests/AutoTest.ArgumentNullException.Tests/AutoTest.ArgumentNullException.Tests.csproj
+++ b/src/Tests/AutoTest.ArgumentNullException.Tests/AutoTest.ArgumentNullException.Tests.csproj
@@ -30,12 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Moq, Version=4.5.21.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moq.4.5.21\lib\net45\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.5.3.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.5.3\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Ploeh.AutoFixture, Version=3.50.2.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">

--- a/src/Tests/AutoTest.ArgumentNullException.Tests/app.config
+++ b/src/Tests/AutoTest.ArgumentNullException.Tests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.5.21.0" newVersion="4.5.21.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.5.3.0" newVersion="4.5.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Ploeh.AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />

--- a/src/Tests/AutoTest.ArgumentNullException.Tests/packages.config
+++ b/src/Tests/AutoTest.ArgumentNullException.Tests/packages.config
@@ -3,9 +3,8 @@
   <package id="AutoFixture" version="3.50.2" targetFramework="net45" />
   <package id="AutoFixture.AutoMoq" version="3.50.2" targetFramework="net45" />
   <package id="AutoFixture.Xunit2" version="3.50.2" targetFramework="net45" />
-  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
   <package id="coveralls.io" version="1.3.4" targetFramework="net45" />
-  <package id="Moq" version="4.5.21" targetFramework="net45" />
+  <package id="Moq" version="4.5.3" targetFramework="net45" />
   <package id="OpenCover" version="4.6.519" targetFramework="net45" />
   <package id="ReportGenerator" version="2.4.5.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />

--- a/src/Tests/AutoTest.ExampleLibrary.Tests/AutoTest.ExampleLibrary.Tests.csproj
+++ b/src/Tests/AutoTest.ExampleLibrary.Tests/AutoTest.ExampleLibrary.Tests.csproj
@@ -30,12 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Moq, Version=4.5.21.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moq.4.5.21\lib\net45\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.5.3.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.5.3\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Ploeh.AutoFixture, Version=3.50.2.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">

--- a/src/Tests/AutoTest.ExampleLibrary.Tests/app.config
+++ b/src/Tests/AutoTest.ExampleLibrary.Tests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.5.21.0" newVersion="4.5.21.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.5.3.0" newVersion="4.5.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Ploeh.AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />

--- a/src/Tests/AutoTest.ExampleLibrary.Tests/packages.config
+++ b/src/Tests/AutoTest.ExampleLibrary.Tests/packages.config
@@ -3,8 +3,7 @@
   <package id="AutoFixture" version="3.50.2" targetFramework="net45" />
   <package id="AutoFixture.AutoMoq" version="3.50.2" targetFramework="net45" />
   <package id="AutoFixture.Xunit2" version="3.50.2" targetFramework="net45" />
-  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
-  <package id="Moq" version="4.5.21" targetFramework="net45" />
+  <package id="Moq" version="4.5.3" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />


### PR DESCRIPTION
The build was failing inconsistently with errors coming out of Castle.Core, see builds [0.7.0.56](https://ci.appveyor.com/project/JSkimming/autotest-argumentnullexception/build/0.7.0.56/tests "Test results of build 0.7.0.56") & [0.7.0.57](https://ci.appveyor.com/project/JSkimming/autotest-argumentnullexception/build/0.7.0.57/tests "Test results of build 0.7.0.57").

A recent upgrade to Moq no longer embeds Castle.Core but references it as a NuGet package.

On a hunch, I downgraded Moq to [4.5.3](https://www.nuget.org/packages/Moq/4.5.3 "Moq version 4.5.3") the last version that still embeds Castle.Core, and it seems to have fix the build 👊

:shipit: