### PR TITLE
Moq no longer supports .NET Core 1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,31 +32,6 @@ orbs:
           - store_test_results:
               path: ./test/TestResults/output/
 
-      # The --no-restore parameter was added in .NET Core 2, so add a dedicated job for building .NET Core 1.1
-      run-build-1-1:
-        parameters:
-          build-config:
-            description: The build configuration, either Debug or Release.
-            type: string
-        executor:
-          name: dotnet-build-executor
-          tag: "1.1"
-        steps:
-          - checkout
-          - run:
-              name: Restore
-              command: dotnet restore
-          - run:
-              name: Build
-              command: |
-                dotnet build -f netcoreapp1.1 -c << parameters.build-config >> ./test/AutoTest.ArgumentNullException.Tests/AutoTest.ArgumentNullException.Tests.csproj
-                dotnet build -f netcoreapp1.1 -c << parameters.build-config >> ./test/AutoTest.ExampleLibrary.Tests/AutoTest.ExampleLibrary.Tests.csproj
-          - run:
-              name: Test
-              command: |
-                dotnet test --no-build -f netcoreapp1.1 -c << parameters.build-config >> ./test/AutoTest.ArgumentNullException.Tests/AutoTest.ArgumentNullException.Tests.csproj
-                dotnet test --no-build -f netcoreapp1.1 -c << parameters.build-config >> ./test/AutoTest.ExampleLibrary.Tests/AutoTest.ExampleLibrary.Tests.csproj
-
     executors:
 
       dotnet-build-executor:
@@ -73,12 +48,6 @@ workflows:
     jobs:
       - shellcheck/check:
           name: shellcheck
-      - build/run-build-1-1:
-          name: 1.1 Debug Build
-          build-config: Debug
-      - build/run-build-1-1:
-          name: 1.1 Release Build
-          build-config: Release
       - build/run-build:
           name: 2.1 Debug Build
           image-tag: "2.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,35 +11,6 @@ RUN find . -type f -name '*.sh' -exec dos2unix {} \;
 RUN find . -type f -name '*.sh' | wc -l && find . -type f -name '*.sh' | xargs shellcheck --external-sources
 
 ########################################################################################################################
-# .NET Core 1.1
-FROM mcr.microsoft.com/dotnet/core/sdk:1.1
-
-ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
-
-WORKDIR /work
-
-# Copy just the solution and proj files to make best use of docker image caching.
-COPY ./autotest.argumentnullexception.sln .
-COPY ./src/AutoTest.ArgumentNullException/AutoTest.ArgumentNullException.csproj ./src/AutoTest.ArgumentNullException/AutoTest.ArgumentNullException.csproj
-COPY ./src/AutoTest.ArgumentNullException.Xunit/AutoTest.ArgumentNullException.Xunit.csproj ./src/AutoTest.ArgumentNullException.Xunit/AutoTest.ArgumentNullException.Xunit.csproj
-COPY ./test/AutoTest.ArgumentNullException.Tests/AutoTest.ArgumentNullException.Tests.csproj ./test/AutoTest.ArgumentNullException.Tests/AutoTest.ArgumentNullException.Tests.csproj
-COPY ./test/AutoTest.ExampleLibrary/AutoTest.ExampleLibrary.csproj ./test/AutoTest.ExampleLibrary/AutoTest.ExampleLibrary.csproj
-COPY ./test/AutoTest.ExampleLibrary.Tests/AutoTest.ExampleLibrary.Tests.csproj ./test/AutoTest.ExampleLibrary.Tests/AutoTest.ExampleLibrary.Tests.csproj
-
-# Run restore on just the project files, this should cache the image after restore.
-RUN dotnet restore
-
-COPY . .
-
-# Build to ensure the tests are their own distinct step
-RUN dotnet build -f netcoreapp1.1 -c Debug ./test/AutoTest.ArgumentNullException.Tests/AutoTest.ArgumentNullException.Tests.csproj
-RUN dotnet build -f netcoreapp1.1 -c Debug ./test/AutoTest.ExampleLibrary.Tests/AutoTest.ExampleLibrary.Tests.csproj
-
-# Run unit tests
-RUN dotnet test --no-build -f netcoreapp1.1 -c Debug ./test/AutoTest.ArgumentNullException.Tests/AutoTest.ArgumentNullException.Tests.csproj
-RUN dotnet test --no-build -f netcoreapp1.1 -c Debug ./test/AutoTest.ExampleLibrary.Tests/AutoTest.ExampleLibrary.Tests.csproj
-
-########################################################################################################################
 # .NET Core 2.1
 FROM mcr.microsoft.com/dotnet/core/sdk:2.1-alpine
 

--- a/test/AutoTest.ArgumentNullException.Tests/AutoTest.ArgumentNullException.Tests.csproj
+++ b/test/AutoTest.ArgumentNullException.Tests/AutoTest.ArgumentNullException.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>AutoTest.ArgNullEx</RootNamespace>
     <IsPackable>false</IsPackable>
@@ -28,14 +28,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\AutoTest.ArgumentNullException.Xunit\AutoTest.ArgumentNullException.Xunit.csproj" />
     <ProjectReference Include="..\..\src\AutoTest.ArgumentNullException\AutoTest.ArgumentNullException.csproj" />
-  </ItemGroup>
-
-  <!--
-  Cannot Create mocks of MethodBase and ParameterInfo in 1.1, as this is an issue with the tests not the library, it's
-  simper to just exclude these tests.
-  -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <Compile Remove="Filter\**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AutoTest.ExampleLibrary.Tests/AutoTest.ExampleLibrary.Tests.csproj
+++ b/test/AutoTest.ExampleLibrary.Tests/AutoTest.ExampleLibrary.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>AutoTest.ExampleLibrary</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/test/AutoTest.ExampleLibrary/AutoTest.ExampleLibrary.csproj
+++ b/test/AutoTest.ExampleLibrary/AutoTest.ExampleLibrary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard1.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
Moq [removed support](https://github.com/moq/moq4/blob/master/CHANGELOG.md#4110-rc1-2019-04-19 "Moq changelog for 4.11.0-rc1 (2019-04-19)") for .NET Core 1.1, because it reaches [end-of-life](https://devblogs.microsoft.com/dotnet/net-core-1-0-and-1-1-will-reach-end-of-life-on-june-27-2019/ ".NET Core 1.0 and 1.1 will reach End of Life on June 27, 2019") on the 27th June 2019.